### PR TITLE
Allow farmers to configure how many nodes they want to periodically power on at the same time

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,12 +128,14 @@ Example:
 The powermanagement behavior is configurable through the following attributes (they are optional):
 - wake_up_threshold => a value between 50 and 80 defining the threshold at which nodes will be powered on or off. If the usage percentage (total used resources devided by the total amount of resources) is greater then the threshold a new node will be powered on. In the other case the farmerbot will try to power off nodes if possible.
 - periodic_wakeup => the time at which the periodic wakeups (powering on a node that is off) should happen. The offline nodes will be powered on sequentially with an interval of 5 minutes starting at the time defined in periodic_wakeup.
+- periodic_wakeup_limit => by default only one node will be woken up every 5 minutes during a periodic wakeup. You can change that behavior by setting the periodic_wakeup_limit setting. 
 
 Example:
 ```
 !!farmerbot.powermanager.configure
     wake_up_threshold:75
     periodic_wakeup:8:30AM
+    periodic_wakeup_limit:2
 ```
 
 ### Example of a configuration file

--- a/farmerbot/system/model.v
+++ b/farmerbot/system/model.v
@@ -4,9 +4,10 @@ import math { ceil }
 import time { Duration, Time }
 
 pub const (
-	default_wake_up_threshold = 80
-	min_wake_up_threshold     = 50
-	max_wake_up_threshold     = 80
+	default_wakeup_threshold = 80
+	default_periodic_wakeup_limit = 1
+	min_wakeup_threshold     = 50
+	max_wakeup_threshold     = 80
 )
 
 pub enum FarmerbotState as u8 {
@@ -121,9 +122,10 @@ fn (a Capacity) - (b Capacity) Capacity {
 [heap]
 pub struct DB {
 pub mut:
-	wake_up_threshold     u8 = system.default_wake_up_threshold
+	wake_up_threshold     u8 = system.default_wakeup_threshold
 	periodic_wakeup_start Duration
 	periodic_wakeup_end   Duration
+	periodic_wakeup_limit u8 = system.default_periodic_wakeup_limit
 	nodes                 map[u32]&Node
 	farm                  &Farm
 }

--- a/tests/README.md
+++ b/tests/README.md
@@ -26,28 +26,29 @@ Structuring tests with these 3 parts will result in tests that easy to read, tha
 
 ```
 fn test_find_node_that_is_on_first() {
-	mut testenvironment := TestEnvironment{}
-	testenvironment.run(fn (mut farmerbot Farmerbot, mut client Client) ! {
-		// prepare
-		farmerbot.db.nodes[3].powerstate = .off
-		mut args := Params {}
-		// can fit on node with id 3 but it is offline so use 5
-		add_required_resources(mut args, "500GB", "100GB", "4GB", "2")
+	run_test("test_find_node_that_is_on_first", 
+		fn (mut farmerbot Farmerbot, mut client Client) ! {
+			// prepare
+			farmerbot.db.nodes[3].powerstate = .off
+			mut args := Params {}
+			// can fit on node with id 3 but it is offline so use 5
+			add_required_resources(mut args, "500GB", "100GB", "4GB", "2")
 
-		// act
-		mut job := client.job_new_wait(
-			twinid: 162
-			action: system.job_node_find
-			args: args
-			actionsource: ""
-		) or {
-			return error("failed to create and wait for job")
+			// act
+			mut job := client.job_new_wait(
+				twinid: 162
+				action: system.job_node_find
+				args: args
+				actionsource: ""
+			) or {
+				return error("failed to create and wait for job")
+			}
+
+			//assert
+			ensure_no_error(&job)!
+			ensure_result_contains_u32(&job, "nodeid", 5)!
 		}
-
-		//assert
-		ensure_no_error(&job)!
-		ensure_result_contains_u32(&job, "nodeid", 5)!
-	})!
+	)!
 }
 ```
 


### PR DESCRIPTION
This completes #12:
- new configuration *periodic_wakeup_limit* that is default 1 and allows you to define how many nodes you want to wakeup at the same time during a periodic wakeup.
- added tests
- added documentation