### PR TITLE
Add build files for ARM

### DIFF
--- a/.github/workflows/publish_arm.yml
+++ b/.github/workflows/publish_arm.yml
@@ -1,0 +1,56 @@
+name: Publish ARM
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        include:
+          - dockerfile: ./arm/Dockerfile
+            image: ghcr.io/${{ github.repository }}
+          - dockerfile: ./arm/file_creator/Dockerfile
+            image: ghcr.io/${{ github.repository }}_config
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ matrix.image }}
+          flavor: |
+            suffix=-arm,onlatest=true
+          tags: |
+            type=semver,pattern={{version}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          context: .
+          platforms: linux/arm64,linux/armhf
+          file: ${{ matrix.dockerfile }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/arm/Dockerfile
+++ b/arm/Dockerfile
@@ -1,0 +1,50 @@
+FROM --platform=$BUILDPLATFORM ubuntu:20.04 AS build
+
+ARG TARGETPLATFORM
+
+RUN apt-get update && \
+    apt-get install -y build-essential gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu git
+
+WORKDIR /opt/vlang
+RUN git clone https://github.com/vlang/v /opt/vlang 
+RUN make
+RUN ./v symlink
+RUN v -version
+
+WORKDIR /baobab
+RUN git clone -b development https://github.com/freeflowuniverse/baobab.git .
+RUN bash install.sh
+
+WORKDIR /crystallib
+RUN git clone -b development https://github.com/freeflowuniverse/crystallib.git .
+RUN bash install.sh
+
+WORKDIR /farmerbot
+COPY . .
+RUN bash install.sh
+RUN if [ $TARGETPLATFORM = linux/arm/v7 ]; then v -prod -cc arm-linux-gnueabihf-gcc main.v; fi
+RUN if [ $TARGETPLATFORM = linux/arm64 ]; then v -prod -cc aarch64-linux-gnu-gcc main.v; fi
+
+# ===== SECOND STAGE ======
+
+FROM ubuntu:20.04
+LABEL description="This is the 2nd stage: a very small image where we copy the farmerbot binary."
+
+COPY --from=build /farmerbot/main /usr/local/bin/farmerbot
+
+RUN apt-get update && apt-get install -y curl ca-certificates libatomic1
+
+# checks
+# RUN ldd /usr/local/bin/farmerbot && /usr/local/bin/farmerbot --version
+
+# Shrinking
+RUN rm -rf /usr/lib/python* && \
+	rm -rf /src && \
+	rm -rf /usr/share/man
+RUN apt-get clean && rm -rf /var/cache/apt/archives/* && \
+    rm -rf /var/lib/apt/lists/*
+
+VOLUME ["/farmerbot"]
+
+ENTRYPOINT ["/usr/local/bin/farmerbot"]
+

--- a/arm/file_creator/Dockerfile
+++ b/arm/file_creator/Dockerfile
@@ -1,0 +1,32 @@
+# ===== FIRST STAGE ======
+# Download the dependencies
+# Create the vlang binaries of file creator
+
+FROM --platform=$BUILDPLATFORM ubuntu:20.04 AS build
+ARG TARGETPLATFORM
+
+RUN apt-get update && \
+    apt-get install -y build-essential gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu git
+RUN apt-get install -y wget
+
+WORKDIR /opt/vlang
+RUN git clone https://github.com/vlang/v /opt/vlang && make && ./v symlink && v -version
+
+WORKDIR /crystallib
+RUN git clone -b development https://github.com/freeflowuniverse/crystallib.git .
+RUN bash install.sh
+
+WORKDIR /farmerbot
+RUN wget https://raw.githubusercontent.com/threefoldtech/farmerbot/development/scripts/file_creator.v
+RUN if [ $TARGETPLATFORM = linux/arm/v7 ]; then v -prod -cc arm-linux-gnueabihf-gcc file_creator.v; fi
+RUN if [ $TARGETPLATFORM = linux/arm64 ]; then v -prod -cc aarch64-linux-gnu-gcc file_creator.v; fi
+
+# ===== SECOND STAGE ======
+# Copy the Farmerbot's file creator binaries
+# Create an entrypoint to run the file creator binaries
+
+FROM ubuntu:20.04
+
+WORKDIR /farmerbot
+COPY --from=build /farmerbot/file_creator /usr/local/bin/file_creator
+ENTRYPOINT /usr/local/bin/file_creator


### PR DESCRIPTION
This PR adds Dockerfiles and Github workflows to automatically build containers for the ARM architecture upon new releases (see #11).

A few notes:

* All changes are adjacent to the existing workflows, to prevent any issues or complications with the mainline builds
* The container images are tagged with a suffix `-arm`, for example `latest-arm` or 0.2.0-arm. While different architecture can coexist under a single tag, it's only possible if all are built under a single workflow run (avoided to preserve the point above)
* Since this and the other workflows needed to support the full farmerbot deployment only trigger when a new tag/release is issued, I've waited to include the new `docker-compose.yaml` file until all are ready. For now, that file is available on my fork and points to the containers built on the set of forks I used for testing
* Any suggestions regarding how to organize the new files, in terms of directory structure or naming conventions, are welcome